### PR TITLE
PlotterMonitor: only autoRange if no max value was given

### DIFF
--- a/plasmoid/contents/ui/PlotterMonitor.qml
+++ b/plasmoid/contents/ui/PlotterMonitor.qml
@@ -53,7 +53,10 @@ Item {
 
         horizontalGridLineCount: 0
 
-        autoRange: true
+        autoRange: plasmoid.configuration.max_value == 0.0
+
+	rangeMin: 0
+	rangeMax: 1
 
         dataSets: make_data_set()
     }


### PR DESCRIPTION
Currently, the PlotterMonitor does auto-ranging of the plotter. However,
if we explicitly specified a maximum value, that doesn't make much
sense, because it renders the maximum value pretty much ineffective.
Therefore, enable autoRange only if max_value is not set.

This requires us to set an explicit rangeMin and rangeMax. rangeMin is
forced to zero (which may or may not be appropriate, but we currently
don't have a configuration option for it). rangeMax is set to 1 because
the data is normalized so that it is 1 if it reaches max_value.

Note that if autoRange is true, rangeMin and rangeMax are ignored.

Signed-off-by: Arnout Vandecappelle (Essensium/Mind) <arnout@mind.be>